### PR TITLE
Migrate to mono:slim

### DIFF
--- a/containers/tshock-dev/932/Dockerfile
+++ b/containers/tshock-dev/932/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/932/Dockerfile
+++ b/containers/tshock-dev/932/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/934/Dockerfile
+++ b/containers/tshock-dev/934/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/934/Dockerfile
+++ b/containers/tshock-dev/934/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/949/Dockerfile
+++ b/containers/tshock-dev/949/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/949/Dockerfile
+++ b/containers/tshock-dev/949/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/962/Dockerfile
+++ b/containers/tshock-dev/962/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/962/Dockerfile
+++ b/containers/tshock-dev/962/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/963/Dockerfile
+++ b/containers/tshock-dev/963/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/963/Dockerfile
+++ b/containers/tshock-dev/963/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/964/Dockerfile
+++ b/containers/tshock-dev/964/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/964/Dockerfile
+++ b/containers/tshock-dev/964/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/966/Dockerfile
+++ b/containers/tshock-dev/966/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/966/Dockerfile
+++ b/containers/tshock-dev/966/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/968/Dockerfile
+++ b/containers/tshock-dev/968/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/968/Dockerfile
+++ b/containers/tshock-dev/968/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/970/Dockerfile
+++ b/containers/tshock-dev/970/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/970/Dockerfile
+++ b/containers/tshock-dev/970/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock-dev/971/Dockerfile
+++ b/containers/tshock-dev/971/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock-dev/971/Dockerfile
+++ b/containers/tshock-dev/971/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.16/Dockerfile
+++ b/containers/tshock/4.3.16/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.16/Dockerfile
+++ b/containers/tshock/4.3.16/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.17/Dockerfile
+++ b/containers/tshock/4.3.17/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.17/Dockerfile
+++ b/containers/tshock/4.3.17/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.18/Dockerfile
+++ b/containers/tshock/4.3.18/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.18/Dockerfile
+++ b/containers/tshock/4.3.18/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.19/Dockerfile
+++ b/containers/tshock/4.3.19/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.19/Dockerfile
+++ b/containers/tshock/4.3.19/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.20/Dockerfile
+++ b/containers/tshock/4.3.20/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.20/Dockerfile
+++ b/containers/tshock/4.3.20/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.22/Dockerfile
+++ b/containers/tshock/4.3.22/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.22/Dockerfile
+++ b/containers/tshock/4.3.22/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.23/Dockerfile
+++ b/containers/tshock/4.3.23/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.23/Dockerfile
+++ b/containers/tshock/4.3.23/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.24/Dockerfile
+++ b/containers/tshock/4.3.24/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.24/Dockerfile
+++ b/containers/tshock/4.3.24/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.25/Dockerfile
+++ b/containers/tshock/4.3.25/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.25/Dockerfile
+++ b/containers/tshock/4.3.25/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/tshock/4.3.26/Dockerfile
+++ b/containers/tshock/4.3.26/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/tshock/4.3.26/Dockerfile
+++ b/containers/tshock/4.3.26/Dockerfile
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/containers/vanilla/1.3.1.1/Dockerfile
+++ b/containers/vanilla/1.3.1.1/Dockerfile
@@ -1,15 +1,15 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # fix for favorites.json error
 RUN favorites_path="/root/My Games/Terraria" && mkdir -p "$favorites_path" && echo "{}" > "$favorites_path/favorites.json"
 
-# Download and install TShock
 ENV VANILLA_VERSION=1311
 
 RUN mkdir /tmp/terraria && \

--- a/containers/vanilla/1.3.1.1/Dockerfile
+++ b/containers/vanilla/1.3.1.1/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/vanilla/1.3.2.1/Dockerfile
+++ b/containers/vanilla/1.3.2.1/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/vanilla/1.3.2.1/Dockerfile
+++ b/containers/vanilla/1.3.2.1/Dockerfile
@@ -1,15 +1,15 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # fix for favorites.json error
 RUN favorites_path="/root/My Games/Terraria" && mkdir -p "$favorites_path" && echo "{}" > "$favorites_path/favorites.json"
 
-# Download and install TShock
 ENV VANILLA_VERSION=1321
 
 RUN mkdir /tmp/terraria && \

--- a/containers/vanilla/1.3.3.3/Dockerfile
+++ b/containers/vanilla/1.3.3.3/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/vanilla/1.3.3.3/Dockerfile
+++ b/containers/vanilla/1.3.3.3/Dockerfile
@@ -1,15 +1,15 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # fix for favorites.json error
 RUN favorites_path="/root/My Games/Terraria" && mkdir -p "$favorites_path" && echo "{}" > "$favorites_path/favorites.json"
 
-# Download and install TShock
 ENV VANILLA_VERSION=1333
 
 RUN mkdir /tmp/terraria && \

--- a/containers/vanilla/1.3.4.4/Dockerfile
+++ b/containers/vanilla/1.3.4.4/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/vanilla/1.3.4.4/Dockerfile
+++ b/containers/vanilla/1.3.4.4/Dockerfile
@@ -1,15 +1,15 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # fix for favorites.json error
 RUN favorites_path="/root/My Games/Terraria" && mkdir -p "$favorites_path" && echo "{}" > "$favorites_path/favorites.json"
 
-# Download and install TShock
 ENV VANILLA_VERSION=1344
 
 RUN mkdir /tmp/terraria && \

--- a/containers/vanilla/1.3.5.3/Dockerfile
+++ b/containers/vanilla/1.3.5.3/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/vanilla/1.3.5.3/Dockerfile
+++ b/containers/vanilla/1.3.5.3/Dockerfile
@@ -1,15 +1,15 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # fix for favorites.json error
 RUN favorites_path="/root/My Games/Terraria" && mkdir -p "$favorites_path" && echo "{}" > "$favorites_path/favorites.json"
 
-# Download and install TShock
 ENV VANILLA_VERSION=1353
 
 RUN mkdir /tmp/terraria && \

--- a/containers/vanilla/1.4.0.2/Dockerfile
+++ b/containers/vanilla/1.4.0.2/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/vanilla/1.4.0.2/Dockerfile
+++ b/containers/vanilla/1.4.0.2/Dockerfile
@@ -1,15 +1,15 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # fix for favorites.json error
 RUN favorites_path="/root/My Games/Terraria" && mkdir -p "$favorites_path" && echo "{}" > "$favorites_path/favorites.json"
 
-# Download and install TShock
 ENV VANILLA_VERSION=1402
 
 RUN mkdir /tmp/terraria && \

--- a/template/tshock-dev/Dockerfile.template
+++ b/template/tshock-dev/Dockerfile.template
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/template/tshock-dev/Dockerfile.template
+++ b/template/tshock-dev/Dockerfile.template
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/template/tshock/Dockerfile.template
+++ b/template/tshock/Dockerfile.template
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/template/tshock/Dockerfile.template
+++ b/template/tshock/Dockerfile.template
@@ -1,10 +1,11 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create symbolic link to ServerLog.txt
 RUN mkdir /config /tshock && \

--- a/template/vanilla/Dockerfile.template
+++ b/template/vanilla/Dockerfile.template
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl vim zip && \
+    apt-get install -y curl nuget vim zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/template/vanilla/Dockerfile.template
+++ b/template/vanilla/Dockerfile.template
@@ -1,15 +1,15 @@
-FROM mono
+FROM mono:slim
 
 # Update and install a zip utility
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y vim zip && \
-    apt-get clean
+    apt-get install -y curl vim zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # fix for favorites.json error
 RUN favorites_path="/root/My Games/Terraria" && mkdir -p "$favorites_path" && echo "{}" > "$favorites_path/favorites.json"
 
-# Download and install TShock
 ENV VANILLA_VERSION=%%VERSION%%
 
 RUN mkdir /tmp/terraria && \


### PR DESCRIPTION
In the interest of keeping the image lightweight, this PR migrates to using `mono:slim` (`debian:slim`) instead of `mono` (`debian`).

This closes #5.