### PR TITLE
Handle SIGTERM by saving world and shutting down gracefully

### DIFF
--- a/template/vanilla/Dockerfile.template
+++ b/template/vanilla/Dockerfile.template
@@ -3,7 +3,7 @@ FROM mono:slim
 # Update and install needed utils
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl nuget vim zip && \
+    apt-get install -y curl nuget vim zip procps && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/template/vanilla/run-vanilla.sh
+++ b/template/vanilla/run-vanilla.sh
@@ -27,5 +27,42 @@ if [ "${world:-null}" != null ]; then
     CMD="$CMD -world /config/$world"
 fi
 
+# Create named pipe if one doesn't already exist
+# This is so we can send input to TerrariaServer
+if [ ! -p "/vanilla/console" ]; then
+    mkfifo /vanilla/console
+fi
+
+# trap SIGTERM signal and call graceful_shutdown
+trap 'kill ${!}; graceful_shutdown' SIGTERM
+
+function graceful_shutdown() {
+    # Send a message to players that the server is shutting down
+    echo say 'Server shutting down' > /vanilla/console
+
+    echo "Stopping Terraria server..."
+    echo "Saving world"
+
+    echo exit  > /vanilla/console
+
+    # Waiting for server to finish saving & shutting down
+    pid=$(pgrep -f ^./TerrariaServer)
+    if [ -z "$pid" ]; then exit 1; fi
+    while [ -e /proc/$pid ]; do
+        sleep 1
+    done
+    echo "World save complete"
+    echo "Shutting down"
+    exit 0
+}
+
 echo "Starting container, CMD: $CMD $@"
-exec $CMD $@
+(tail -f > /vanilla/console & $CMD $@ < console) &
+
+tail -f /dev/null & wait ${!}
+
+pid=$(pgrep -f ^./TerrariaServer)
+if [ -z "$pid" ]; then exit 1; fi
+while [ -e /proc/$pid ]; do
+   sleep 5
+done


### PR DESCRIPTION
This is an initial attempt at a way to handle restarts and shutdowns gracefully as a resolution for https://github.com/beardedio/terraria/issues/4

It does this by sending the 'exit' command to the TerrariaServer stdin which saves the world and shuts down the server.
It was based on https://github.com/alexivkin/terraria-server-container/blob/master/buildcontext/serverwatcher.sh

I've tested this with vanilla-1.4.2.1. If this looks like a good approach, I can do some testing with TShock to see if a similar approach would work for those images.
