### PR TITLE
Changed update workflow to run hourly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
       - containers/**
       - template/**
   schedule:
-    - cron:  '0 9 * * *' # UTC
+    - cron:  '0 0/1 * * *' # run hourly
 
 jobs:
   build:


### PR DESCRIPTION
This changes the update workflow to run hourly. Steam automatically updates within minutes after an update is released. The server only pushing new images once a day renders the game unplayable for half a day (on average) after an update is released.

I don't want to manually downgrade every time Re-Logic is pushing updates, i.e. twice a month at the moment...